### PR TITLE
Added the parameter type of the custom label

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ export module clarity {
      */
     export function setTag(
       key: string,
-      value: string
+      value: string | string[]
     ): void;
   
     /**


### PR DESCRIPTION
The Clarity custom tag feature supports strings or arrays of strings in the official documentation, so update the parameter types here.

https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-api#add-custom-tags

